### PR TITLE
- dont show sets, use real imdbtop 250

### DIFF
--- a/playlists/video/Top250Movies.xsp
+++ b/playlists/video/Top250Movies.xsp
@@ -3,5 +3,6 @@
     <name>Imdb Top 250</name>
     <match>all</match>
     <rule field="top250" operator="isnot">0</rule>
+    <group>none</group>
     <order direction="ascending">top250</order>
 </smartplaylist>


### PR DESCRIPTION
Hi, again first thanks , to add the imbd playlist
- i didnt check, that it's also included userdata playlists ,to chosse from 

I add <group>tag with value none, to not show sets in first place, this way its a true "imdb top250" order
(needed if the setting Group movies into sets is enabled).
Danke