### PR TITLE
prefer thumb for episodes

### DIFF
--- a/xml/Embuary_ItemLayouts.xml
+++ b/xml/Embuary_ItemLayouts.xml
@@ -928,6 +928,14 @@
 						</visible>
 					</control>
 					<control type="image">
+						<width>300</width>
+						<height>100</height>
+						<bottom>10</bottom>
+						<texture background="true" fallback="">$INFO[ListItem.Art(tvshow.clearlogo)]</texture>
+						<aspectratio align="left" aligny="bottom">keep</aspectratio>
+						<visible>[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + [!String.IsEqual(ListItem.Art(thumb),OverlaySpoiler.png) | String.Contains(ListItem.Art(thumb),default) + String.IsEmpty(ListItem.Art(tvshow.landscape))]</visible>
+					</control>
+					<control type="image">
 						<width>430</width>
 						<height>242</height>
 						<texture background="true">$INFO[ListItem.Icon]</texture>

--- a/xml/Embuary_Variables.xml
+++ b/xml/Embuary_Variables.xml
@@ -626,13 +626,15 @@
 		<value condition="!String.IsEmpty(ListItem.EpgEventIcon)">$INFO[ListItem.EpgEventIcon]</value>
 		<value condition="String.StartsWith(ListItem.Path,pvr://) + !String.StartsWith(ListItem.Icon,Default)">$INFO[ListItem.Icon]</value>
 		<!-- episodes -->
-		<value condition="Window.IsVisible(1115) + String.IsEqual(ListItem.DBType,episode) + !String.StartsWith(ListItem.Art(thumb),Default)">$VAR[IconEpisodeThumb]</value>
-		<value condition="[Window.IsVisible(movieinformation) | Window.IsVisible(favourites)] + [String.IsEqual(ListItem.DBType,episode) | !String.IsEmpty(ListItem.Episode)] + !String.StartsWith(ListItem.Art(thumb),Default)">$VAR[IconEpisodeThumb]</value>
-		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + Window.IsMedia + !String.StartsWith(ListItem.Art(thumb),Default)">$VAR[IconEpisodeThumb]</value>
+		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + String.IsEqual(ListItem.Art(thumb),OverlaySpoiler.png) + !String.IsEmpty(ListItem.Art(tvshow.landscape))">$INFO[ListItem.Art(tvshow.landscape)]</value>
+		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + String.IsEqual(ListItem.Art(thumb),OverlaySpoiler.png) + String.IsEmpty(ListItem.Art(tvshow.landscape)) + !String.IsEmpty(ListItem.Art(tvshow.fanart))">$INFO[ListItem.Art(tvshow.fanart)]</value>
+		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + String.IsEqual(ListItem.Art(thumb),OverlaySpoiler.png) + String.IsEmpty(ListItem.Art(tvshow.landscape)) + String.IsEmpty(ListItem.Art(tvshow.fanart))">special://skin/extras/themes/$VAR[SkinTheme]/unwatched.jpg</value>
+		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + !String.IsEmpty(ListItem.Art(thumb))">$INFO[ListItem.Art(thumb)]</value>
 		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + !String.IsEmpty(ListItem.Art(tvshow.landscape))">$INFO[ListItem.Art(tvshow.landscape)]</value>
 		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + !String.IsEmpty(ListItem.Art(landscape))">$INFO[ListItem.Art(landscape)]</value>
 		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + !String.IsEmpty(ListItem.Art(tvshow.fanart))">$INFO[ListItem.Art(tvshow.fanart)]</value>
 		<value condition="[String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)] + !String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="String.IsEqual(ListItem.DBType,episode) | Container.Content(episodes)">$INFO[ListItem.Icon]</value>
 		<!-- tvshows -->
 		<value condition="[String.IsEqual(ListItem.DBType,season) | Container.Content(seasons)] + !String.IsEmpty(ListItem.Art(tvshow.landscape))">$INFO[ListItem.Art(season.landscape)]</value>
 		<value condition="[String.IsEqual(ListItem.DBType,season) | Container.Content(seasons)] + !String.IsEmpty(ListItem.Art(landscape))">$INFO[ListItem.Art(landscape)]</value>
@@ -649,15 +651,6 @@
 		<value condition="!String.IsEmpty(ListItem.Art(fanart)) + [!String.IsEmpty(ListItem.DBType) | ListItem.IsFolder | String.StartsWith(ListItem.Icon,Default) | String.StartsWith(ListItem.Path,plugin://) | Window.IsVisible(addonbrowser) | Window.IsVisible(programs) | Container.Content(addons)]">$INFO[ListItem.Art(fanart)]</value>
 		<value condition="!String.IsEmpty(ListItem.Property(fanart))">$INFO[ListItem.Property(fanart)]</value>
 		<value condition="!String.StartsWith(ListItem.Icon,Default)">$INFO[ListItem.Icon]</value>
-	</variable>
-	<variable name="IconEpisodeThumb">
-		<value condition="String.IsEqual(ListItem.Art(thumb),OverlaySpoiler.png)">special://skin/extras/themes/$VAR[SkinTheme]/unwatched.jpg</value>
-		<value condition="!String.IsEmpty(ListItem.Art(thumb))">$INFO[ListItem.Art(thumb)]</value>
-		<value condition="!String.IsEmpty(ListItem.Art(tvshow.landscape))">$INFO[ListItem.Art(tvshow.landscape)]</value>
-		<value condition="!String.IsEmpty(ListItem.Art(landscape))">$INFO[ListItem.Art(landscape)]</value>
-		<value condition="!String.IsEmpty(ListItem.Art(tvshow.fanart))">$INFO[ListItem.Art(tvshow.fanart)]</value>
-		<value condition="!String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
-		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="IconListView">
 		<value condition="Window.IsVisible(MyPVRRecordings.xml) + !String.IsEqual(ListItem.ActualIcon,ListItem.Icon)">$INFO[ListItem.ActualIcon]</value>


### PR DESCRIPTION
Hi, unsure if its really an improvement for the skin or just personal preference.

that pr will prefer thumbs for episodes and use clearlogo overlay(if avail) ,
also makes the variable IconListView obsolete,and is therefore deleted.

- it gives
 - a) bit more diversification for inprogress episodes of same tvshow.
 - b) uses landscape/ or fanart with clearlogo overlay instead of just the "unwatched.jpg" logo

It respects the kodi settikng (dont show "thumb-spoiler" if unwatched)

video proof: https://streamable.com/opvnq