### PR TITLE
Add Jellyfin Rotten Tomatoes rating

### DIFF
--- a/xml/Embuary_MetaIncludes.xml
+++ b/xml/Embuary_MetaIncludes.xml
@@ -762,7 +762,7 @@
 				<height>20</height>
 				<texture>icons/rating/rotten_fresh.png</texture>
 				<aspectratio>keep</aspectratio>
-				<visible>!String.IsEmpty($PARAM[type].UserRating) + Integer.IsGreater($PARAM[type].UserRating,59) + [System.HasAddon(plugin.video.emby) | String.StartsWith(ListItem.Path,plugin://plugin.video.embycon) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
+				<visible>!String.IsEmpty($PARAM[type].UserRating) + Integer.IsGreater($PARAM[type].UserRating,59) + [System.HasAddon(plugin.video.emby) | System.HasAddon(plugin.video.jellyfin) | String.StartsWith(ListItem.Path,plugin://plugin.video.embycon) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
 			</control>e
 			<control type="image">
 				<animation effect="slide" end="0,3" time="0" condition="true">Conditional</animation>
@@ -770,12 +770,12 @@
 				<height>20</height>
 				<texture>icons/rating/rotten_rotten.png</texture>
 				<aspectratio>keep</aspectratio>
-				<visible>!String.IsEmpty($PARAM[type].UserRating) + !Integer.IsGreater($PARAM[type].UserRating,59) + [System.HasAddon(plugin.video.emby) | String.StartsWith(ListItem.Path,plugin://plugin.video.embycon) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
+				<visible>!String.IsEmpty($PARAM[type].UserRating) + !Integer.IsGreater($PARAM[type].UserRating,59) + [System.HasAddon(plugin.video.emby) | System.HasAddon(plugin.video.jellyfin) | String.StartsWith(ListItem.Path,plugin://plugin.video.embycon) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
 			</control>
 			<control type="label">
 				<label>$INFO[$PARAM[type].UserRating]   </label>
 				<include>MetaLabel</include>
-				<visible>!String.IsEmpty($PARAM[type].UserRating) + [System.HasAddon(plugin.video.emby) | String.StartsWith(ListItem.Path,plugin://plugin.video.embycon) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
+				<visible>!String.IsEmpty($PARAM[type].UserRating) + [System.HasAddon(plugin.video.emby) | System.HasAddon(plugin.video.jellyfin) | String.StartsWith(ListItem.Path,plugin://plugin.video.embycon) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
 			</control>
 		</definition>
 	</include>

--- a/xml/VideoFullScreen.xml
+++ b/xml/VideoFullScreen.xml
@@ -348,7 +348,7 @@
 						<height>20</height>
 						<texture>icons/rating/rotten_fresh.png</texture>
 						<aspectratio>keep</aspectratio>
-						<visible>!String.IsEmpty(VideoPlayer.UserRating) + Integer.IsGreater(VideoPlayer.UserRating,59) + [System.HasAddon(plugin.video.emby) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
+						<visible>!String.IsEmpty(VideoPlayer.UserRating) + Integer.IsGreater(VideoPlayer.UserRating,59) + [System.HasAddon(plugin.video.emby) | System.HasAddon(plugin.video.jellyfin) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
 						<visible>!String.Contains(Player.Art(thumb),KodiCinemaMode)</visible>
 					</control>
 					<control type="image" id="99">
@@ -357,7 +357,7 @@
 						<height>20</height>
 						<texture>icons/rating/rotten_rotten.png</texture>
 						<aspectratio>keep</aspectratio>
-						<visible>!String.IsEmpty(VideoPlayer.UserRating) + !Integer.IsGreater(VideoPlayer.UserRating,59) + [System.HasAddon(plugin.video.emby) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
+						<visible>!String.IsEmpty(VideoPlayer.UserRating) + !Integer.IsGreater(VideoPlayer.UserRating,59) + [System.HasAddon(plugin.video.emby) | System.HasAddon(plugin.video.jellyfin) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
 						<visible>!String.Contains(Player.Art(thumb),KodiCinemaMode)</visible>
 					</control>
 					<control type="label" id="99">
@@ -367,7 +367,7 @@
 						<label>$INFO[VideoPlayer.UserRating]   </label>
 						<font>reg24</font>
 						<textcolor>white</textcolor>
-						<visible>!String.IsEmpty(VideoPlayer.UserRating) + [System.HasAddon(plugin.video.emby) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
+						<visible>!String.IsEmpty(VideoPlayer.UserRating) + [System.HasAddon(plugin.video.emby) | System.HasAddon(plugin.video.jellyfin) | String.Contains(Player.Filenameandpath,/emby/)]</visible>
 						<visible>!String.Contains(Player.Art(thumb),KodiCinemaMode)</visible>
 					</control>
 				</control>


### PR DESCRIPTION
Show Jellyfin Rotten Tomatoes ratings in the same way as Emby add-on