### PR TITLE
fix typo -  double '>>'

### DIFF
--- a/xml/Embuary_Includes.xml
+++ b/xml/Embuary_Includes.xml
@@ -4,7 +4,7 @@
 		<width>$PARAM[width]</width>
 	</include>
 	<include name="ParamMovement">
-		<movement>$PARAM[nr]</movement>>
+		<movement>$PARAM[nr]</movement>
 	</include>
 	<include name="ContainerContentPath">
 		<param name="showdummy">false</param>


### PR DESCRIPTION
also found here

 xml\Embuary_Includes.xml (1 hit)
	Line 7: 		<movement>$PARAM[nr]</movement>>
  xml\Embuary_Variables.xml (1 hit)
	Line 1157: 	<variable name="PlayerTimeLabels">>
  xml\script-skinshortcuts.xml (1 hit)
	Line 30: 		<control type="grouplist" id="20">>

...no more time to pr