### PR TITLE
support plugin urls without trailing slash

### DIFF
--- a/xml/Embuary_Variables.xml
+++ b/xml/Embuary_Variables.xml
@@ -1520,183 +1520,153 @@
 		<value>defaultembuary.png</value>
 	</variable>
 	<variable name="CWidgetReloadPath1">
-		<value condition="String.StartsWith(Skin.String(UserWidget1_path),plugin://) + String.Contains(Skin.String(UserWidget1_path),/?)">$INFO[Skin.String(UserWidget1_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget1_path),plugin://) + !String.EndsWith(Skin.String(UserWidget1_path),/)">$INFO[Skin.String(UserWidget1_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget1_path),plugin://) + String.EndsWith(Skin.String(UserWidget1_path),/)">$INFO[Skin.String(UserWidget1_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget1_path),plugin://) + String.Contains(Skin.String(UserWidget1_path),?)">$INFO[Skin.String(UserWidget1_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget1_path),plugin://)">$INFO[Skin.String(UserWidget1_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget1_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath2">
-		<value condition="String.StartsWith(Skin.String(UserWidget2_path),plugin://) + String.Contains(Skin.String(UserWidget2_path),/?)">$INFO[Skin.String(UserWidget2_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget2_path),plugin://) + !String.EndsWith(Skin.String(UserWidget2_path),/)">$INFO[Skin.String(UserWidget2_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget2_path),plugin://) + String.EndsWith(Skin.String(UserWidget2_path),/)">$INFO[Skin.String(UserWidget2_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget2_path),plugin://) + String.Contains(Skin.String(UserWidget2_path),?)">$INFO[Skin.String(UserWidget2_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget2_path),plugin://)">$INFO[Skin.String(UserWidget2_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget2_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath3">
-		<value condition="String.StartsWith(Skin.String(UserWidget3_path),plugin://) + String.Contains(Skin.String(UserWidget3_path),/?)">$INFO[Skin.String(UserWidget3_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget3_path),plugin://) + !String.EndsWith(Skin.String(UserWidget3_path),/)">$INFO[Skin.String(UserWidget3_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget3_path),plugin://) + String.EndsWith(Skin.String(UserWidget3_path),/)">$INFO[Skin.String(UserWidget3_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget3_path),plugin://) + String.Contains(Skin.String(UserWidget3_path),?)">$INFO[Skin.String(UserWidget3_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget3_path),plugin://)">$INFO[Skin.String(UserWidget3_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget3_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath4">
-		<value condition="String.StartsWith(Skin.String(UserWidget4_path),plugin://) + String.Contains(Skin.String(UserWidget4_path),/?)">$INFO[Skin.String(UserWidget4_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget4_path),plugin://) + !String.EndsWith(Skin.String(UserWidget4_path),/)">$INFO[Skin.String(UserWidget4_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget4_path),plugin://) + String.EndsWith(Skin.String(UserWidget4_path),/)">$INFO[Skin.String(UserWidget4_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget4_path),plugin://) + String.Contains(Skin.String(UserWidget4_path),?)">$INFO[Skin.String(UserWidget4_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget4_path),plugin://)">$INFO[Skin.String(UserWidget4_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget4_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath5">
-		<value condition="String.StartsWith(Skin.String(UserWidget5_path),plugin://) + String.Contains(Skin.String(UserWidget5_path),/?)">$INFO[Skin.String(UserWidget5_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget5_path),plugin://) + !String.EndsWith(Skin.String(UserWidget5_path),/)">$INFO[Skin.String(UserWidget5_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget5_path),plugin://) + String.EndsWith(Skin.String(UserWidget5_path),/)">$INFO[Skin.String(UserWidget5_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget5_path),plugin://) + String.Contains(Skin.String(UserWidget5_path),?)">$INFO[Skin.String(UserWidget5_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget5_path),plugin://)">$INFO[Skin.String(UserWidget5_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget5_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath6">
-		<value condition="String.StartsWith(Skin.String(UserWidget6_path),plugin://) + String.Contains(Skin.String(UserWidget6_path),/?)">$INFO[Skin.String(UserWidget6_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget6_path),plugin://) + !String.EndsWith(Skin.String(UserWidget6_path),/)">$INFO[Skin.String(UserWidget6_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget6_path),plugin://) + String.EndsWith(Skin.String(UserWidget6_path),/)">$INFO[Skin.String(UserWidget6_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget6_path),plugin://) + String.Contains(Skin.String(UserWidget6_path),?)">$INFO[Skin.String(UserWidget6_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget6_path),plugin://)">$INFO[Skin.String(UserWidget6_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget6_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath7">
-		<value condition="String.StartsWith(Skin.String(UserWidget7_path),plugin://) + String.Contains(Skin.String(UserWidget7_path),/?)">$INFO[Skin.String(UserWidget7_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget7_path),plugin://) + !String.EndsWith(Skin.String(UserWidget7_path),/)">$INFO[Skin.String(UserWidget7_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget7_path),plugin://) + String.EndsWith(Skin.String(UserWidget7_path),/)">$INFO[Skin.String(UserWidget7_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget7_path),plugin://) + String.Contains(Skin.String(UserWidget7_path),?)">$INFO[Skin.String(UserWidget7_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget7_path),plugin://)">$INFO[Skin.String(UserWidget7_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget7_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath8">
-		<value condition="String.StartsWith(Skin.String(UserWidget8_path),plugin://) + String.Contains(Skin.String(UserWidget8_path),/?)">$INFO[Skin.String(UserWidget8_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget8_path),plugin://) + !String.EndsWith(Skin.String(UserWidget8_path),/)">$INFO[Skin.String(UserWidget8_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget8_path),plugin://) + String.EndsWith(Skin.String(UserWidget8_path),/)">$INFO[Skin.String(UserWidget8_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget8_path),plugin://) + String.Contains(Skin.String(UserWidget8_path),?)">$INFO[Skin.String(UserWidget8_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget8_path),plugin://)">$INFO[Skin.String(UserWidget8_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget8_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath9">
-		<value condition="String.StartsWith(Skin.String(UserWidget9_path),plugin://) + String.Contains(Skin.String(UserWidget9_path),/?)">$INFO[Skin.String(UserWidget9_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget9_path),plugin://) + !String.EndsWith(Skin.String(UserWidget9_path),/)">$INFO[Skin.String(UserWidget9_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget9_path),plugin://) + String.EndsWith(Skin.String(UserWidget9_path),/)">$INFO[Skin.String(UserWidget9_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget9_path),plugin://) + String.Contains(Skin.String(UserWidget9_path),?)">$INFO[Skin.String(UserWidget9_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget9_path),plugin://)">$INFO[Skin.String(UserWidget9_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget9_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath10">
-		<value condition="String.StartsWith(Skin.String(UserWidget10_path),plugin://) + String.Contains(Skin.String(UserWidget10_path),/?)">$INFO[Skin.String(UserWidget10_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget10_path),plugin://) + !String.EndsWith(Skin.String(UserWidget10_path),/)">$INFO[Skin.String(UserWidget10_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget10_path),plugin://) + String.EndsWith(Skin.String(UserWidget10_path),/)">$INFO[Skin.String(UserWidget10_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget10_path),plugin://) + String.Contains(Skin.String(UserWidget10_path),?)">$INFO[Skin.String(UserWidget10_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget10_path),plugin://)">$INFO[Skin.String(UserWidget10_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget10_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath11">
-		<value condition="String.StartsWith(Skin.String(UserWidget11_path),plugin://) + String.Contains(Skin.String(UserWidget11_path),/?)">$INFO[Skin.String(UserWidget11_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget11_path),plugin://) + !String.EndsWith(Skin.String(UserWidget11_path),/)">$INFO[Skin.String(UserWidget11_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget11_path),plugin://) + String.EndsWith(Skin.String(UserWidget11_path),/)">$INFO[Skin.String(UserWidget11_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget11_path),plugin://) + String.Contains(Skin.String(UserWidget11_path),?)">$INFO[Skin.String(UserWidget11_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget11_path),plugin://)">$INFO[Skin.String(UserWidget11_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget11_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath12">
-		<value condition="String.StartsWith(Skin.String(UserWidget12_path),plugin://) + String.Contains(Skin.String(UserWidget12_path),/?)">$INFO[Skin.String(UserWidget12_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget12_path),plugin://) + !String.EndsWith(Skin.String(UserWidget12_path),/)">$INFO[Skin.String(UserWidget12_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget12_path),plugin://) + String.EndsWith(Skin.String(UserWidget12_path),/)">$INFO[Skin.String(UserWidget12_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget12_path),plugin://) + String.Contains(Skin.String(UserWidget12_path),?)">$INFO[Skin.String(UserWidget12_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget12_path),plugin://)">$INFO[Skin.String(UserWidget12_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget12_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath13">
-		<value condition="String.StartsWith(Skin.String(UserWidget13_path),plugin://) + String.Contains(Skin.String(UserWidget13_path),/?)">$INFO[Skin.String(UserWidget13_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget13_path),plugin://) + !String.EndsWith(Skin.String(UserWidget13_path),/)">$INFO[Skin.String(UserWidget13_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget13_path),plugin://) + String.EndsWith(Skin.String(UserWidget13_path),/)">$INFO[Skin.String(UserWidget13_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget13_path),plugin://) + String.Contains(Skin.String(UserWidget13_path),?)">$INFO[Skin.String(UserWidget13_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget13_path),plugin://)">$INFO[Skin.String(UserWidget13_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget13_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath14">
-		<value condition="String.StartsWith(Skin.String(UserWidget14_path),plugin://) + String.Contains(Skin.String(UserWidget14_path),/?)">$INFO[Skin.String(UserWidget14_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget14_path),plugin://) + !String.EndsWith(Skin.String(UserWidget14_path),/)">$INFO[Skin.String(UserWidget14_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget14_path),plugin://) + String.EndsWith(Skin.String(UserWidget14_path),/)">$INFO[Skin.String(UserWidget14_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget14_path),plugin://) + String.Contains(Skin.String(UserWidget14_path),?)">$INFO[Skin.String(UserWidget14_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget14_path),plugin://)">$INFO[Skin.String(UserWidget14_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget14_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath15">
-		<value condition="String.StartsWith(Skin.String(UserWidget15_path),plugin://) + String.Contains(Skin.String(UserWidget15_path),/?)">$INFO[Skin.String(UserWidget15_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget15_path),plugin://) + !String.EndsWith(Skin.String(UserWidget15_path),/)">$INFO[Skin.String(UserWidget15_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget15_path),plugin://) + String.EndsWith(Skin.String(UserWidget15_path),/)">$INFO[Skin.String(UserWidget15_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget15_path),plugin://) + String.Contains(Skin.String(UserWidget15_path),?)">$INFO[Skin.String(UserWidget15_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget15_path),plugin://)">$INFO[Skin.String(UserWidget15_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget15_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath16">
-		<value condition="String.StartsWith(Skin.String(UserWidget16_path),plugin://) + String.Contains(Skin.String(UserWidget16_path),/?)">$INFO[Skin.String(UserWidget16_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget16_path),plugin://) + !String.EndsWith(Skin.String(UserWidget16_path),/)">$INFO[Skin.String(UserWidget16_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget16_path),plugin://) + String.EndsWith(Skin.String(UserWidget16_path),/)">$INFO[Skin.String(UserWidget16_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget16_path),plugin://) + String.Contains(Skin.String(UserWidget16_path),?)">$INFO[Skin.String(UserWidget16_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget16_path),plugin://)">$INFO[Skin.String(UserWidget16_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget16_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath17">
-		<value condition="String.StartsWith(Skin.String(UserWidget17_path),plugin://) + String.Contains(Skin.String(UserWidget17_path),/?)">$INFO[Skin.String(UserWidget17_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget17_path),plugin://) + !String.EndsWith(Skin.String(UserWidget17_path),/)">$INFO[Skin.String(UserWidget17_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget17_path),plugin://) + String.EndsWith(Skin.String(UserWidget17_path),/)">$INFO[Skin.String(UserWidget17_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget17_path),plugin://) + String.Contains(Skin.String(UserWidget17_path),?)">$INFO[Skin.String(UserWidget17_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget17_path),plugin://)">$INFO[Skin.String(UserWidget17_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget17_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath18">
-		<value condition="String.StartsWith(Skin.String(UserWidget18_path),plugin://) + String.Contains(Skin.String(UserWidget18_path),/?)">$INFO[Skin.String(UserWidget18_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget18_path),plugin://) + !String.EndsWith(Skin.String(UserWidget18_path),/)">$INFO[Skin.String(UserWidget18_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget18_path),plugin://) + String.EndsWith(Skin.String(UserWidget18_path),/)">$INFO[Skin.String(UserWidget18_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget18_path),plugin://) + String.Contains(Skin.String(UserWidget18_path),?)">$INFO[Skin.String(UserWidget18_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget18_path),plugin://)">$INFO[Skin.String(UserWidget18_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget18_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath19">
-		<value condition="String.StartsWith(Skin.String(UserWidget19_path),plugin://) + String.Contains(Skin.String(UserWidget19_path),/?)">$INFO[Skin.String(UserWidget19_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget19_path),plugin://) + !String.EndsWith(Skin.String(UserWidget19_path),/)">$INFO[Skin.String(UserWidget19_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget19_path),plugin://) + String.EndsWith(Skin.String(UserWidget19_path),/)">$INFO[Skin.String(UserWidget19_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget19_path),plugin://) + String.Contains(Skin.String(UserWidget19_path),?)">$INFO[Skin.String(UserWidget19_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget19_path),plugin://)">$INFO[Skin.String(UserWidget19_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget19_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath20">
-		<value condition="String.StartsWith(Skin.String(UserWidget20_path),plugin://) + String.Contains(Skin.String(UserWidget20_path),/?)">$INFO[Skin.String(UserWidget20_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget20_path),plugin://) + !String.EndsWith(Skin.String(UserWidget20_path),/)">$INFO[Skin.String(UserWidget20_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget20_path),plugin://) + String.EndsWith(Skin.String(UserWidget20_path),/)">$INFO[Skin.String(UserWidget20_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget20_path),plugin://) + String.Contains(Skin.String(UserWidget20_path),?)">$INFO[Skin.String(UserWidget20_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget20_path),plugin://)">$INFO[Skin.String(UserWidget20_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget20_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath21">
-		<value condition="String.StartsWith(Skin.String(UserWidget21_path),plugin://) + String.Contains(Skin.String(UserWidget21_path),/?)">$INFO[Skin.String(UserWidget21_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget21_path),plugin://) + !String.EndsWith(Skin.String(UserWidget21_path),/)">$INFO[Skin.String(UserWidget21_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget21_path),plugin://) + String.EndsWith(Skin.String(UserWidget21_path),/)">$INFO[Skin.String(UserWidget21_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget21_path),plugin://) + String.Contains(Skin.String(UserWidget21_path),?)">$INFO[Skin.String(UserWidget21_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget21_path),plugin://)">$INFO[Skin.String(UserWidget21_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget21_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath22">
-		<value condition="String.StartsWith(Skin.String(UserWidget22_path),plugin://) + String.Contains(Skin.String(UserWidget22_path),/?)">$INFO[Skin.String(UserWidget22_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget22_path),plugin://) + !String.EndsWith(Skin.String(UserWidget22_path),/)">$INFO[Skin.String(UserWidget22_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget22_path),plugin://) + String.EndsWith(Skin.String(UserWidget22_path),/)">$INFO[Skin.String(UserWidget22_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget22_path),plugin://) + String.Contains(Skin.String(UserWidget22_path),?)">$INFO[Skin.String(UserWidget22_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget22_path),plugin://)">$INFO[Skin.String(UserWidget22_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget22_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath23">
-		<value condition="String.StartsWith(Skin.String(UserWidget23_path),plugin://) + String.Contains(Skin.String(UserWidget23_path),/?)">$INFO[Skin.String(UserWidget23_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget23_path),plugin://) + !String.EndsWith(Skin.String(UserWidget23_path),/)">$INFO[Skin.String(UserWidget23_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget23_path),plugin://) + String.EndsWith(Skin.String(UserWidget23_path),/)">$INFO[Skin.String(UserWidget23_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget23_path),plugin://) + String.Contains(Skin.String(UserWidget23_path),?)">$INFO[Skin.String(UserWidget23_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget23_path),plugin://)">$INFO[Skin.String(UserWidget23_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget23_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath24">
-		<value condition="String.StartsWith(Skin.String(UserWidget24_path),plugin://) + String.Contains(Skin.String(UserWidget24_path),/?)">$INFO[Skin.String(UserWidget24_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget24_path),plugin://) + !String.EndsWith(Skin.String(UserWidget24_path),/)">$INFO[Skin.String(UserWidget24_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget24_path),plugin://) + String.EndsWith(Skin.String(UserWidget24_path),/)">$INFO[Skin.String(UserWidget24_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget24_path),plugin://) + String.Contains(Skin.String(UserWidget24_path),?)">$INFO[Skin.String(UserWidget24_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget24_path),plugin://)">$INFO[Skin.String(UserWidget24_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget24_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath25">
-		<value condition="String.StartsWith(Skin.String(UserWidget25_path),plugin://) + String.Contains(Skin.String(UserWidget25_path),/?)">$INFO[Skin.String(UserWidget25_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget25_path),plugin://) + !String.EndsWith(Skin.String(UserWidget25_path),/)">$INFO[Skin.String(UserWidget25_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget25_path),plugin://) + String.EndsWith(Skin.String(UserWidget25_path),/)">$INFO[Skin.String(UserWidget25_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget25_path),plugin://) + String.Contains(Skin.String(UserWidget25_path),?)">$INFO[Skin.String(UserWidget25_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget25_path),plugin://)">$INFO[Skin.String(UserWidget25_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget25_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath26">
-		<value condition="String.StartsWith(Skin.String(UserWidget26_path),plugin://) + String.Contains(Skin.String(UserWidget26_path),/?)">$INFO[Skin.String(UserWidget26_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget26_path),plugin://) + !String.EndsWith(Skin.String(UserWidget26_path),/)">$INFO[Skin.String(UserWidget26_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget26_path),plugin://) + String.EndsWith(Skin.String(UserWidget26_path),/)">$INFO[Skin.String(UserWidget26_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget26_path),plugin://) + String.Contains(Skin.String(UserWidget26_path),?)">$INFO[Skin.String(UserWidget26_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget26_path),plugin://)">$INFO[Skin.String(UserWidget26_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget26_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath27">
-		<value condition="String.StartsWith(Skin.String(UserWidget27_path),plugin://) + String.Contains(Skin.String(UserWidget27_path),/?)">$INFO[Skin.String(UserWidget27_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget27_path),plugin://) + !String.EndsWith(Skin.String(UserWidget27_path),/)">$INFO[Skin.String(UserWidget27_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget27_path),plugin://) + String.EndsWith(Skin.String(UserWidget27_path),/)">$INFO[Skin.String(UserWidget27_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget27_path),plugin://) + String.Contains(Skin.String(UserWidget27_path),?)">$INFO[Skin.String(UserWidget27_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget27_path),plugin://)">$INFO[Skin.String(UserWidget27_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget27_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath28">
-		<value condition="String.StartsWith(Skin.String(UserWidget28_path),plugin://) + String.Contains(Skin.String(UserWidget28_path),/?)">$INFO[Skin.String(UserWidget28_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget28_path),plugin://) + !String.EndsWith(Skin.String(UserWidget28_path),/)">$INFO[Skin.String(UserWidget28_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget28_path),plugin://) + String.EndsWith(Skin.String(UserWidget28_path),/)">$INFO[Skin.String(UserWidget28_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget28_path),plugin://) + String.Contains(Skin.String(UserWidget28_path),?)">$INFO[Skin.String(UserWidget28_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget28_path),plugin://)">$INFO[Skin.String(UserWidget28_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget28_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath29">
-		<value condition="String.StartsWith(Skin.String(UserWidget29_path),plugin://) + String.Contains(Skin.String(UserWidget29_path),/?)">$INFO[Skin.String(UserWidget29_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget29_path),plugin://) + !String.EndsWith(Skin.String(UserWidget29_path),/)">$INFO[Skin.String(UserWidget29_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget29_path),plugin://) + String.EndsWith(Skin.String(UserWidget29_path),/)">$INFO[Skin.String(UserWidget29_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget29_path),plugin://) + String.Contains(Skin.String(UserWidget29_path),?)">$INFO[Skin.String(UserWidget29_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget29_path),plugin://)">$INFO[Skin.String(UserWidget29_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget29_path)]</value>
 	</variable>
 	<variable name="CWidgetReloadPath30">
-		<value condition="String.StartsWith(Skin.String(UserWidget30_path),plugin://) + String.Contains(Skin.String(UserWidget30_path),/?)">$INFO[Skin.String(UserWidget30_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget30_path),plugin://) + !String.EndsWith(Skin.String(UserWidget30_path),/)">$INFO[Skin.String(UserWidget30_path)]/?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
-		<value condition="String.StartsWith(Skin.String(UserWidget30_path),plugin://) + String.EndsWith(Skin.String(UserWidget30_path),/)">$INFO[Skin.String(UserWidget30_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget30_path),plugin://) + String.Contains(Skin.String(UserWidget30_path),?)">$INFO[Skin.String(UserWidget30_path)]&amp;reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
+		<value condition="String.StartsWith(Skin.String(UserWidget30_path),plugin://)">$INFO[Skin.String(UserWidget30_path)]?reload=$INFO[Window(home).Property(EmbuaryWidgetUpdate)]</value>
 		<value>$INFO[Skin.String(UserWidget30_path)]</value>
 	</variable>
 	<variable name="CWidgetDefaultIcon">


### PR DESCRIPTION
The widget functionality in the Embuary skin only supports plugin urls ending **with** a trailing slash. This makes that widgets from Kodi add-ons that use plugin urls **without** a trailing slash are not loaded and display an error. This is especially the case for add-ons using [kodi-plugin-routing](https://github.com/tamland/kodi-plugin-routing) for clean plugin urls.

This pull request makes the trailing slash in the widget functionality of the Embuary skin optional.