### PR TITLE
Keep aspect ratio of posters

### DIFF
--- a/xml/Embuary_ItemLayouts.xml
+++ b/xml/Embuary_ItemLayouts.xml
@@ -281,7 +281,7 @@
 						<width>237</width>
 						<height>355</height>
 						<texture background="true">$PARAM[icon]</texture>
-						<aspectratio scalediffuse="false">stretch</aspectratio>
+						<aspectratio scalediffuse="false">scale</aspectratio>
 					</control>
 					<control type="group">
 						<width>237</width>


### PR DESCRIPTION
Although I guess it could be subjective, but I find scaled (as opposed to stretched) posters more appealing :slightly_smiling_face: 