### PR TITLE
Add CECstandby option in the power menu.

### DIFF
--- a/language/resource.language.da_DK/strings.po
+++ b/language/resource.language.da_DK/strings.po
@@ -1691,3 +1691,8 @@ msgstr "Holdet"
 msgctxt "#31322"
 msgid "More seasons"
 msgstr "Flere sæsoner"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Sluk for tv'et"

--- a/language/resource.language.de_DE/strings.po
+++ b/language/resource.language.de_DE/strings.po
@@ -2178,3 +2178,8 @@ msgstr "OK, zur Whitelist hinzufügen"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "Kodi neustarten"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Schalte den Fernseher aus"

--- a/language/resource.language.en_GB/strings.po
+++ b/language/resource.language.en_GB/strings.po
@@ -2102,3 +2102,8 @@ msgstr ""
 msgctxt "#31416"
 msgid "Media type"
 msgstr ""
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Turn off the TV"

--- a/language/resource.language.es_ES/strings.po
+++ b/language/resource.language.es_ES/strings.po
@@ -2168,3 +2168,8 @@ msgstr ""
 msgctxt "#31411"
 msgid "OK, add found to whitelist"
 msgstr ""
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Apagar la televisión"

--- a/language/resource.language.es_MX/strings.po
+++ b/language/resource.language.es_MX/strings.po
@@ -2182,3 +2182,8 @@ msgstr "OK, agregar lo encontrado a la lista blanca"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "Reiniciar Kodi"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Apagar la televisión"

--- a/language/resource.language.fr_FR/strings.po
+++ b/language/resource.language.fr_FR/strings.po
@@ -2165,3 +2165,8 @@ msgstr ""
 msgctxt "#31411"
 msgid "OK, add found to whitelist"
 msgstr ""
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Éteins la télévision"

--- a/language/resource.language.hu_HU/strings.po
+++ b/language/resource.language.hu_HU/strings.po
@@ -1337,3 +1337,8 @@ msgstr "hub"
 msgctxt "#31254"
 msgid "Hide main menu and only show widgets"
 msgstr "A főmenü elrejtése és csak a modulok megjelenítése"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Kapcsolja ki a TV-t"

--- a/language/resource.language.it_IT/strings.po
+++ b/language/resource.language.it_IT/strings.po
@@ -2182,3 +2182,8 @@ msgstr "OK, aggiungi trovato alla whitelist"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "Riavvia Kodi"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Spegni la televisione"

--- a/language/resource.language.ko_KR/strings.po
+++ b/language/resource.language.ko_KR/strings.po
@@ -1715,3 +1715,8 @@ msgstr "재생 및 미디어 작업의 동작 변경"
 msgctxt "#31330"
 msgid "Playback & media"
 msgstr "재생 & 미디어"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "TV를 꺼"

--- a/language/resource.language.nl_NL/strings.po
+++ b/language/resource.language.nl_NL/strings.po
@@ -2180,3 +2180,8 @@ msgstr "OK, gevonden items toevoegen aan witte lijst"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "Kodi opnieuw opstarten"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Zet de tv uit"

--- a/language/resource.language.pl_PL/strings.po
+++ b/language/resource.language.pl_PL/strings.po
@@ -2171,3 +2171,8 @@ msgstr "OK, dodaj znalezione do listy wyjątków"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "Uruchom ponownie Kodi"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Wyłączyć telewizor"

--- a/language/resource.language.pt_BR/strings.po
+++ b/language/resource.language.pt_BR/strings.po
@@ -2165,3 +2165,8 @@ msgstr ""
 msgctxt "#31411"
 msgid "OK, add found to whitelist"
 msgstr ""
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Desligue a televisão"

--- a/language/resource.language.pt_PT/strings.po
+++ b/language/resource.language.pt_PT/strings.po
@@ -2156,3 +2156,8 @@ msgstr ""
 msgctxt "#31411"
 msgid "OK, add found to whitelist"
 msgstr ""
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Desligue a televisão"

--- a/language/resource.language.ru_RU/strings.po
+++ b/language/resource.language.ru_RU/strings.po
@@ -2173,3 +2173,8 @@ msgstr "Хорошо, добавить в белый список"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "Перезапустить Kodi"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Выключить телевизор"

--- a/language/resource.language.sv_SE/strings.po
+++ b/language/resource.language.sv_SE/strings.po
@@ -1047,3 +1047,8 @@ msgstr "Göm etiketter"
 msgctxt "#31199"
 msgid "Slide"
 msgstr ""
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Stäng av tv: n"

--- a/language/resource.language.tr_TR/strings.po
+++ b/language/resource.language.tr_TR/strings.po
@@ -2200,3 +2200,8 @@ msgstr "Sağlayıcı"
 msgctxt "#31416"
 msgid "Media type"
 msgstr "Medya türü"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "Televizyonu kapat"

--- a/language/resource.language.zh_CN/strings.po
+++ b/language/resource.language.zh_CN/strings.po
@@ -2127,3 +2127,8 @@ msgstr "好，将找到的添加到白名单"
 msgctxt "#31412"
 msgid "Restart Kodi"
 msgstr "重新启动Kodi"
+
+#: /xml/DialogButtonMenu.xml
+msgctxt "#31417"
+msgid "Turn off the TV"
+msgstr "关掉电视"

--- a/xml/DialogButtonMenu.xml
+++ b/xml/DialogButtonMenu.xml
@@ -151,7 +151,7 @@
 				</focusedlayout>
 				<content>
 					<item>
-						<label>$LOCALIZE[33060] $LOCALIZE[351] $LOCALIZE[36037]</label>
+						<label>$LOCALIZE[31417]</label>
 						<label2>&#xf425;</label2>
 						<onclick>PlayerControl(Stop)</onclick>
 						<onclick>Dialog.Close(all,true)</onclick>

--- a/xml/DialogButtonMenu.xml
+++ b/xml/DialogButtonMenu.xml
@@ -151,6 +151,15 @@
 				</focusedlayout>
 				<content>
 					<item>
+						<label>$LOCALIZE[33060] $LOCALIZE[351] $LOCALIZE[36037]</label>
+						<label2>&#xf425;</label2>
+						<onclick>PlayerControl(Stop)</onclick>
+						<onclick>Dialog.Close(all,true)</onclick>
+						<onclick>CECStandby</onclick>
+						<property name="color">red</property>
+						<visible>Skin.HasSetting(ShowCecStandby)</visible>
+					</item>
+					<item>
 						<label>$LOCALIZE[10000]</label>
 						<label2>&#xf2dc;</label2>
 						<onclick>Dialog.Close(all,true)</onclick>

--- a/xml/Embuary_SkinSettings.xml
+++ b/xml/Embuary_SkinSettings.xml
@@ -857,6 +857,12 @@
 			<label>$LOCALIZE[13017] / $LOCALIZE[13018]</label>
 			<visible>System.HasShutdown</visible>
 		</control>
+		<control type="radiobutton" id="$PARAM[id]12">
+			<include>SettingsButton</include>
+			<onclick>Skin.ToggleSetting(ShowCecStandby)</onclick>
+			<selected>Skin.HasSetting(ShowCecStandby)</selected>
+			<label>$LOCALIZE[33060] $LOCALIZE[351] $LOCALIZE[36037]</label>
+		</control>
 	</include>
 
 	<!-- dependencies -->

--- a/xml/Embuary_SkinSettings.xml
+++ b/xml/Embuary_SkinSettings.xml
@@ -861,7 +861,7 @@
 			<include>SettingsButton</include>
 			<onclick>Skin.ToggleSetting(ShowCecStandby)</onclick>
 			<selected>Skin.HasSetting(ShowCecStandby)</selected>
-			<label>$LOCALIZE[33060] $LOCALIZE[351] $LOCALIZE[36037]</label>
+			<label>$LOCALIZE[31417]</label>
 		</control>
 	</include>
 


### PR DESCRIPTION
For regular set top box users, it is convinient to be able to turn off the TV from the set top box menu.

With running Kodi on single-board-computers like RaspberryPi being common, this button provides an easier option to turn off the TV.